### PR TITLE
GameDB: EA Sports BIO (NTSC-U) Support

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -40410,6 +40410,9 @@ SLUS-20719:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
+  memcardFilters:
+    - "PSCD10088" # Enables EA Sports BIO (2004-only Cross Game Profile System)
+    - "SLUS-20719"
 SLUS-20720:
   name: "Romance of the Three Kingdoms VIII"
   region: "NTSC-U"
@@ -40550,6 +40553,9 @@ SLUS-20750:
   compat: 5
   clampModes:
     vuClampMode: 2 # Missing geometry with microVU.
+  memcardFilters:
+    - "PSCD10088" # Enables EA Sports BIO (2004-only Cross Game Profile System)
+    - "SLUS-20750"
 SLUS-20751:
   name: "James Bond 007 - Everything or Nothing"
   region: "NTSC-U"
@@ -40559,6 +40565,9 @@ SLUS-20752:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Missing geometry with microVU.
+  memcardFilters:
+    - "PSCD10088" # Enables EA Sports BIO (2004-only Cross Game Profile System)
+    - "SLUS-20752"
 SLUS-20753:
   name: "Medal of Honor - Rising Sun"
   region: "NTSC-U"
@@ -40566,20 +40575,32 @@ SLUS-20753:
 SLUS-20754:
   name: "NASCAR Thunder 2004"
   region: "NTSC-U"
+  memcardFilters:
+    - "PSCD10088" # Enables EA Sports BIO (2004-only Cross Game Profile System)
+    - "SLUS-20754"
 SLUS-20755:
   name: "NBA Live 2004"
   region: "NTSC-U"
   clampModes:
     vuClampMode: 2 # Missing geometry with microVU.
+  memcardFilters:
+    - "PSCD10088" # Enables EA Sports BIO (2004-only Cross Game Profile System)
+    - "SLUS-20755"
 SLUS-20756:
   name: "NHL 2004"
   region: "NTSC-U"
+  memcardFilters:
+    - "PSCD10088" # Enables EA Sports BIO (2004-only Cross Game Profile System)
+    - "SLUS-20756"
 SLUS-20757:
   name: "Tiger Woods PGA Tour 2004"
   region: "NTSC-U"
   compat: 5
   clampModes:
     vuClampMode: 2 # Fixes black textures on characters.
+  memcardFilters:
+    - "PSCD10088" # Enables EA Sports BIO (2004-only Cross Game Profile System)
+    - "SLUS-20757"
 SLUS-20758:
   name: "Growlanser Generations [Disc1of2] - Growlanser II - The Sense of Justice"
   region: "NTSC-U"
@@ -40666,6 +40687,9 @@ SLUS-20771:
   region: "NTSC-U"
   clampModes:
     vuClampMode: 3 # Fixes missing textures.
+  memcardFilters:
+    - "PSCD10088" # Enables EA Sports BIO (2004-only Cross Game Profile System)
+    - "SLUS-20771"
 SLUS-20772:
   name: "SSX 3"
   region: "NTSC-U"
@@ -40866,6 +40890,9 @@ SLUS-20823:
 SLUS-20824:
   name: "NASCAR Thunder 2004"
   region: "NTSC-U"
+  memcardFilters:
+    - "PSCD10088" # Enables EA Sports BIO (2004-only Cross Game Profile System)
+    - "SLUS-20824"
 SLUS-20826:
   name: "Harry Potter & the Sorcerer's Stone"
   region: "NTSC-U"
@@ -41058,6 +41085,9 @@ SLUS-20867:
 SLUS-20868:
   name: "MVP Baseball 2004"
   region: "NTSC-U"
+  memcardFilters:
+    - "PSCD10088" # Enables EA Sports BIO (2004-only Cross Game Profile System)
+    - "SLUS-20868"
 SLUS-20869:
   name: "Judge Dredd - Dredd vs. Death"
   region: "NTSC-U"
@@ -41232,6 +41262,9 @@ SLUS-20906:
   name: "Fight Night 2004"
   region: "NTSC-U"
   compat: 5
+  memcardFilters:
+    - "PSCD10088" # Enables EA Sports BIO (2004-only Cross Game Profile System)
+    - "SLUS-20906"
 SLUS-20907:
   name: "Serious Sam - Next Encounter"
   region: "NTSC-U"


### PR DESCRIPTION
EA Sports BIO was an early form of cross-game profile system used in EA Sports' 2004 sports lineup. It was not used again for 2005, but the idea is novel enough and interesting enough that I felt putting a patch in was a good idea.

Here's an article about it: http://hitthepass.com/the-ea-sports-bio-it-was-in-the-game/
And another one (mostly about NBA Live 2004): https://www.nba-live.com/ww-ea-sports-bio-nba-live-2004/

This only works for NTSC-U as it's the only one I've tested, but I am planning on testing the PAL version as well.
The interesting thing is the use of PSCD10088 (no dash) as a serial. AFAIK that seems to be an internal thing, and not an official serial. Would be interesting if a dev could add some insight.

### Description of Changes
Add memCardFilter to all related games.

### Rationale behind Changes
Allows EA Sports BIO to be used with Folder Memory Cards.

### Suggested Testing Steps
Start the games involved, and save an EA Sports Bio, then save and load in each game, and see if it all reads/writes correctly.